### PR TITLE
mission/computer_upload: fix initial login screen

### DIFF
--- a/addons/missions/functions/fnc_computerUpload.sqf
+++ b/addons/missions/functions/fnc_computerUpload.sqf
@@ -72,10 +72,10 @@ if (isServer) then {
     };
     (call _fnc_randomLastLoginDate) params ["_weekDay", "_month", "_day", "_hours", "_minutes", "_seconds"];
 
-    private _terminalLogin = format [" %1 login: ", _user];
+    private _terminalLogin = format [" %1 login: ", _host];
     private _terminalPrepare = [
         [
-            format ["%1 %2", _terminalLogin, _host],
+            format ["%1 %2", _terminalLogin, _user],
             " Password:"
         ], [
             format [" Last Login: %1 %2 %3 %4:%5:%6 on ttyl", _weekDay, _month, _day, _hours, _minutes, _seconds],


### PR DESCRIPTION
This fixes the incorrect way the initial loading screen shows

wrong way:
<img width="927" height="660" alt="userhostupload" src="https://github.com/user-attachments/assets/f239c5b9-0c61-42d4-81a5-c50601be61a3" />

right way:

<img width="1208" height="876" alt="Screenshot_20250904_213444" src="https://github.com/user-attachments/assets/5492fca8-3895-4e6e-809d-3ddd79f7ef07" />

